### PR TITLE
Fix error setting require_auth=False

### DIFF
--- a/datasette_auth_existing_cookies/__init__.py
+++ b/datasette_auth_existing_cookies/__init__.py
@@ -32,7 +32,7 @@ def asgi_wrapper(datasette):
 
     # require_auth defaults to True unless set otherwise
     require_auth = True
-    if require_auth in config:
+    if "require_auth" in config:
         require_auth = config["require_auth"]
 
     def wrap_with_asgi_auth(app):


### PR DESCRIPTION
This fixes a simple code error that prevents the `require_auth` setting from being anything but the default `True`.